### PR TITLE
Support all current slf4j 1.7.36 logging formats

### DIFF
--- a/src/org/slf4j/LoggerFactory.java
+++ b/src/org/slf4j/LoggerFactory.java
@@ -25,10 +25,11 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 public class LoggerFactory {
 	private static LoggerOption logger_option=new LoggerOption();
-	public static Logger getLogger(Class log_class) {
+	public static Logger getLogger(Class<?> log_class) {
 		return new Logger(log_class, logger_option);
 	}
 }
+
 class LoggerOption {
 	static public LoggerWriter logWriter=new LoggerWriter();//null;
 

--- a/src/org/slf4j/helpers/FormattingTuple.java
+++ b/src/org/slf4j/helpers/FormattingTuple.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2004-2011 QOS.ch
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.slf4j.helpers;
+
+/**
+ * Holds the results of formatting done by {@link MessageFormatter}.
+ * 
+ * @author Joern Huxhorn
+ */
+public class FormattingTuple {
+
+    static public FormattingTuple NULL = new FormattingTuple(null);
+
+    private String message;
+    private Throwable throwable;
+    private Object[] argArray;
+
+    public FormattingTuple(String message) {
+        this(message, null, null);
+    }
+
+    public FormattingTuple(String message, Object[] argArray, Throwable throwable) {
+        this.message = message;
+        this.throwable = throwable;
+        this.argArray = argArray;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public Object[] getArgArray() {
+        return argArray;
+    }
+
+    public Throwable getThrowable() {
+        return throwable;
+    }
+
+}

--- a/src/org/slf4j/helpers/MessageFormatter.java
+++ b/src/org/slf4j/helpers/MessageFormatter.java
@@ -1,0 +1,437 @@
+/**
+ * Copyright (c) 2004-2011 QOS.ch
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.slf4j.helpers;
+
+import java.text.MessageFormat;
+import java.util.HashMap;
+import java.util.Map;
+
+// contributors: lizongbo: proposed special treatment of array parameter values
+// Joern Huxhorn: pointed out double[] omission, suggested deep array copy
+/**
+ * Formats messages according to very simple substitution rules. Substitutions
+ * can be made 1, 2 or more arguments.
+ *
+ * <p>
+ * For example,
+ *
+ * <pre>
+ * MessageFormatter.format(&quot;Hi {}.&quot;, &quot;there&quot;)
+ * </pre>
+ *
+ * will return the string "Hi there.".
+ * <p>
+ * The {} pair is called the <em>formatting anchor</em>. It serves to designate
+ * the location where arguments need to be substituted within the message
+ * pattern.
+ * <p>
+ * In case your message contains the '{' or the '}' character, you do not have
+ * to do anything special unless the '}' character immediately follows '{'. For
+ * example,
+ *
+ * <pre>
+ * MessageFormatter.format(&quot;Set {1,2,3} is not equal to {}.&quot;, &quot;1,2&quot;);
+ * </pre>
+ *
+ * will return the string "Set {1,2,3} is not equal to 1,2.".
+ *
+ * <p>
+ * If for whatever reason you need to place the string "{}" in the message
+ * without its <em>formatting anchor</em> meaning, then you need to escape the
+ * '{' character with '\', that is the backslash character. Only the '{'
+ * character should be escaped. There is no need to escape the '}' character.
+ * For example,
+ *
+ * <pre>
+ * MessageFormatter.format(&quot;Set \\{} is not equal to {}.&quot;, &quot;1,2&quot;);
+ * </pre>
+ *
+ * will return the string "Set {} is not equal to 1,2.".
+ *
+ * <p>
+ * The escaping behavior just described can be overridden by escaping the escape
+ * character '\'. Calling
+ *
+ * <pre>
+ * MessageFormatter.format(&quot;File name is C:\\\\{}.&quot;, &quot;file.zip&quot;);
+ * </pre>
+ *
+ * will return the string "File name is C:\file.zip".
+ *
+ * <p>
+ * The formatting conventions are different than those of {@link MessageFormat}
+ * which ships with the Java platform. This is justified by the fact that
+ * SLF4J's implementation is 10 times faster than that of {@link MessageFormat}.
+ * This local performance difference is both measurable and significant in the
+ * larger context of the complete logging processing chain.
+ *
+ * <p>
+ * See also {@link #format(String, Object)},
+ * {@link #format(String, Object, Object)} and
+ * {@link #arrayFormat(String, Object[])} methods for more details.
+ *
+ * @author Ceki G&uuml;lc&uuml;
+ * @author Joern Huxhorn
+ */
+final public class MessageFormatter {
+    static final char DELIM_START = '{';
+    static final char DELIM_STOP = '}';
+    static final String DELIM_STR = "{}";
+    private static final char ESCAPE_CHAR = '\\';
+
+    /**
+     * Performs single argument substitution for the 'messagePattern' passed as
+     * parameter.
+     * <p>
+     * For example,
+     *
+     * <pre>
+     * MessageFormatter.format(&quot;Hi {}.&quot;, &quot;there&quot;);
+     * </pre>
+     *
+     * will return the string "Hi there.".
+     * <p>
+     *
+     * @param messagePattern
+     *          The message pattern which will be parsed and formatted
+     * @param arg
+     *          The argument to be substituted in place of the formatting anchor
+     * @return The formatted message
+     */
+    final public static FormattingTuple format(String messagePattern, Object arg) {
+        return arrayFormat(messagePattern, new Object[] { arg });
+    }
+
+    /**
+     *
+     * Performs a two argument substitution for the 'messagePattern' passed as
+     * parameter.
+     * <p>
+     * For example,
+     *
+     * <pre>
+     * MessageFormatter.format(&quot;Hi {}. My name is {}.&quot;, &quot;Alice&quot;, &quot;Bob&quot;);
+     * </pre>
+     *
+     * will return the string "Hi Alice. My name is Bob.".
+     *
+     * @param messagePattern
+     *          The message pattern which will be parsed and formatted
+     * @param arg1
+     *          The argument to be substituted in place of the first formatting
+     *          anchor
+     * @param arg2
+     *          The argument to be substituted in place of the second formatting
+     *          anchor
+     * @return The formatted message
+     */
+    final public static FormattingTuple format(final String messagePattern, Object arg1, Object arg2) {
+        return arrayFormat(messagePattern, new Object[] { arg1, arg2 });
+    }
+
+
+    final public static FormattingTuple arrayFormat(final String messagePattern, final Object[] argArray) {
+        Throwable throwableCandidate = MessageFormatter.getThrowableCandidate(argArray);
+        Object[] args = argArray;
+        if (throwableCandidate != null) {
+            args = MessageFormatter.trimmedCopy(argArray);
+        }
+        return arrayFormat(messagePattern, args, throwableCandidate);
+    }
+
+    final public static FormattingTuple arrayFormat(final String messagePattern, final Object[] argArray, Throwable throwable) {
+
+        if (messagePattern == null) {
+            return new FormattingTuple(null, argArray, throwable);
+        }
+
+        if (argArray == null) {
+            return new FormattingTuple(messagePattern);
+        }
+
+        int i = 0;
+        int j;
+        // use string builder for better multicore performance
+        StringBuilder sbuf = new StringBuilder(messagePattern.length() + 50);
+
+        int L;
+        for (L = 0; L < argArray.length; L++) {
+
+            j = messagePattern.indexOf(DELIM_STR, i);
+
+            if (j == -1) {
+                // no more variables
+                if (i == 0) { // this is a simple string
+                    return new FormattingTuple(messagePattern, argArray, throwable);
+                } else { // add the tail string which contains no variables and return
+                    // the result.
+                    sbuf.append(messagePattern, i, messagePattern.length());
+                    return new FormattingTuple(sbuf.toString(), argArray, throwable);
+                }
+            } else {
+                if (isEscapedDelimeter(messagePattern, j)) {
+                    if (!isDoubleEscaped(messagePattern, j)) {
+                        L--; // DELIM_START was escaped, thus should not be incremented
+                        sbuf.append(messagePattern, i, j - 1);
+                        sbuf.append(DELIM_START);
+                        i = j + 1;
+                    } else {
+                        // The escape character preceding the delimiter start is
+                        // itself escaped: "abc x:\\{}"
+                        // we have to consume one backward slash
+                        sbuf.append(messagePattern, i, j - 1);
+                        deeplyAppendParameter(sbuf, argArray[L], new HashMap<Object[], Object>());
+                        i = j + 2;
+                    }
+                } else {
+                    // normal case
+                    sbuf.append(messagePattern, i, j);
+                    deeplyAppendParameter(sbuf, argArray[L], new HashMap<Object[], Object>());
+                    i = j + 2;
+                }
+            }
+        }
+        // append the characters following the last {} pair.
+        sbuf.append(messagePattern, i, messagePattern.length());
+        return new FormattingTuple(sbuf.toString(), argArray, throwable);
+    }
+
+    final static boolean isEscapedDelimeter(String messagePattern, int delimeterStartIndex) {
+
+        if (delimeterStartIndex == 0) {
+            return false;
+        }
+        char potentialEscape = messagePattern.charAt(delimeterStartIndex - 1);
+        if (potentialEscape == ESCAPE_CHAR) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    final static boolean isDoubleEscaped(String messagePattern, int delimeterStartIndex) {
+        if (delimeterStartIndex >= 2 && messagePattern.charAt(delimeterStartIndex - 2) == ESCAPE_CHAR) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    // special treatment of array values was suggested by 'lizongbo'
+    private static void deeplyAppendParameter(StringBuilder sbuf, Object o, Map<Object[], Object> seenMap) {
+        if (o == null) {
+            sbuf.append("null");
+            return;
+        }
+        if (!o.getClass().isArray()) {
+            safeObjectAppend(sbuf, o);
+        } else {
+            // check for primitive array types because they
+            // unfortunately cannot be cast to Object[]
+            if (o instanceof boolean[]) {
+                booleanArrayAppend(sbuf, (boolean[]) o);
+            } else if (o instanceof byte[]) {
+                byteArrayAppend(sbuf, (byte[]) o);
+            } else if (o instanceof char[]) {
+                charArrayAppend(sbuf, (char[]) o);
+            } else if (o instanceof short[]) {
+                shortArrayAppend(sbuf, (short[]) o);
+            } else if (o instanceof int[]) {
+                intArrayAppend(sbuf, (int[]) o);
+            } else if (o instanceof long[]) {
+                longArrayAppend(sbuf, (long[]) o);
+            } else if (o instanceof float[]) {
+                floatArrayAppend(sbuf, (float[]) o);
+            } else if (o instanceof double[]) {
+                doubleArrayAppend(sbuf, (double[]) o);
+            } else {
+                objectArrayAppend(sbuf, (Object[]) o, seenMap);
+            }
+        }
+    }
+
+    private static void safeObjectAppend(StringBuilder sbuf, Object o) {
+        try {
+            String oAsString = o.toString();
+            sbuf.append(oAsString);
+        } catch (Throwable t) {
+            Util.report("SLF4J: Failed toString() invocation on an object of type [" + o.getClass().getName() + "]", t);
+            sbuf.append("[FAILED toString()]");
+        }
+
+    }
+
+    private static void objectArrayAppend(StringBuilder sbuf, Object[] a, Map<Object[], Object> seenMap) {
+        sbuf.append('[');
+        if (!seenMap.containsKey(a)) {
+            seenMap.put(a, null);
+            final int len = a.length;
+            for (int i = 0; i < len; i++) {
+                deeplyAppendParameter(sbuf, a[i], seenMap);
+                if (i != len - 1)
+                    sbuf.append(", ");
+            }
+            // allow repeats in siblings
+            seenMap.remove(a);
+        } else {
+            sbuf.append("...");
+        }
+        sbuf.append(']');
+    }
+
+    private static void booleanArrayAppend(StringBuilder sbuf, boolean[] a) {
+        sbuf.append('[');
+        final int len = a.length;
+        for (int i = 0; i < len; i++) {
+            sbuf.append(a[i]);
+            if (i != len - 1)
+                sbuf.append(", ");
+        }
+        sbuf.append(']');
+    }
+
+    private static void byteArrayAppend(StringBuilder sbuf, byte[] a) {
+        sbuf.append('[');
+        final int len = a.length;
+        for (int i = 0; i < len; i++) {
+            sbuf.append(a[i]);
+            if (i != len - 1)
+                sbuf.append(", ");
+        }
+        sbuf.append(']');
+    }
+
+    private static void charArrayAppend(StringBuilder sbuf, char[] a) {
+        sbuf.append('[');
+        final int len = a.length;
+        for (int i = 0; i < len; i++) {
+            sbuf.append(a[i]);
+            if (i != len - 1)
+                sbuf.append(", ");
+        }
+        sbuf.append(']');
+    }
+
+    private static void shortArrayAppend(StringBuilder sbuf, short[] a) {
+        sbuf.append('[');
+        final int len = a.length;
+        for (int i = 0; i < len; i++) {
+            sbuf.append(a[i]);
+            if (i != len - 1)
+                sbuf.append(", ");
+        }
+        sbuf.append(']');
+    }
+
+    private static void intArrayAppend(StringBuilder sbuf, int[] a) {
+        sbuf.append('[');
+        final int len = a.length;
+        for (int i = 0; i < len; i++) {
+            sbuf.append(a[i]);
+            if (i != len - 1)
+                sbuf.append(", ");
+        }
+        sbuf.append(']');
+    }
+
+    private static void longArrayAppend(StringBuilder sbuf, long[] a) {
+        sbuf.append('[');
+        final int len = a.length;
+        for (int i = 0; i < len; i++) {
+            sbuf.append(a[i]);
+            if (i != len - 1)
+                sbuf.append(", ");
+        }
+        sbuf.append(']');
+    }
+
+    private static void floatArrayAppend(StringBuilder sbuf, float[] a) {
+        sbuf.append('[');
+        final int len = a.length;
+        for (int i = 0; i < len; i++) {
+            sbuf.append(a[i]);
+            if (i != len - 1)
+                sbuf.append(", ");
+        }
+        sbuf.append(']');
+    }
+
+    private static void doubleArrayAppend(StringBuilder sbuf, double[] a) {
+        sbuf.append('[');
+        final int len = a.length;
+        for (int i = 0; i < len; i++) {
+            sbuf.append(a[i]);
+            if (i != len - 1)
+                sbuf.append(", ");
+        }
+        sbuf.append(']');
+    }
+
+    /**
+     * Helper method to determine if an {@link Object} array contains a {@link Throwable} as last element
+     *
+     * @param argArray
+     *          The arguments off which we want to know if it contains a {@link Throwable} as last element
+     * @return if the last {@link Object} in argArray is a {@link Throwable} this method will return it,
+     *          otherwise it returns null
+     */
+    public static Throwable getThrowableCandidate(final Object[] argArray) {
+        if (argArray == null || argArray.length == 0) {
+            return null;
+        }
+
+        final Object lastEntry = argArray[argArray.length - 1];
+        if (lastEntry instanceof Throwable) {
+            return (Throwable) lastEntry;
+        }
+
+        return null;
+    }
+
+    /**
+     * Helper method to get all but the last element of an array
+     *
+     * @param argArray
+     *          The arguments from which we want to remove the last element
+     *
+     * @return a copy of the array without the last element
+     */
+    public static Object[] trimmedCopy(final Object[] argArray) {
+        if (argArray == null || argArray.length == 0) {
+            throw new IllegalStateException("non-sensical empty or null argument array");
+        }
+
+        final int trimmedLen = argArray.length - 1;
+
+        Object[] trimmed = new Object[trimmedLen];
+
+        if (trimmedLen > 0) {
+            System.arraycopy(argArray, 0, trimmed, 0, trimmedLen);
+        }
+
+        return trimmed;
+    }
+
+}

--- a/src/org/slf4j/helpers/Util.java
+++ b/src/org/slf4j/helpers/Util.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2004-2011 QOS.ch
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.slf4j.helpers;
+
+/**
+ * An internal utility class.
+ *
+ * @author Alexander Dorokhine
+ * @author Ceki G&uuml;lc&uuml;
+ */
+public final class Util {
+
+	
+    private Util() {
+    }
+
+    public static String safeGetSystemProperty(String key) {
+        if (key == null)
+            throw new IllegalArgumentException("null input");
+
+        String result = null;
+        try {
+            result = System.getProperty(key);
+        } catch (java.lang.SecurityException sm) {
+            ; // ignore
+        }
+        return result;
+    }
+
+    public static boolean safeGetBooleanSystemProperty(String key) {
+        String value = safeGetSystemProperty(key);
+        if (value == null)
+            return false;
+        else
+            return value.equalsIgnoreCase("true");
+    }
+
+    /**
+     * In order to call {@link SecurityManager#getClassContext()}, which is a
+     * protected method, we add this wrapper which allows the method to be visible
+     * inside this package.
+     */
+    private static final class ClassContextSecurityManager extends SecurityManager {
+        protected Class<?>[] getClassContext() {
+            return super.getClassContext();
+        }
+    }
+
+    private static ClassContextSecurityManager SECURITY_MANAGER;
+    private static boolean SECURITY_MANAGER_CREATION_ALREADY_ATTEMPTED = false;
+
+    private static ClassContextSecurityManager getSecurityManager() {
+        if (SECURITY_MANAGER != null)
+            return SECURITY_MANAGER;
+        else if (SECURITY_MANAGER_CREATION_ALREADY_ATTEMPTED)
+            return null;
+        else {
+            SECURITY_MANAGER = safeCreateSecurityManager();
+            SECURITY_MANAGER_CREATION_ALREADY_ATTEMPTED = true;
+            return SECURITY_MANAGER;
+        }
+    }
+
+    private static ClassContextSecurityManager safeCreateSecurityManager() {
+        try {
+            return new ClassContextSecurityManager();
+        } catch (java.lang.SecurityException sm) {
+            return null;
+        }
+    }
+
+    /**
+     * Returns the name of the class which called the invoking method.
+     *
+     * @return the name of the class which called the invoking method.
+     */
+    public static Class<?> getCallingClass() {
+        ClassContextSecurityManager securityManager = getSecurityManager();
+        if (securityManager == null)
+            return null;
+        Class<?>[] trace = securityManager.getClassContext();
+        String thisClassName = Util.class.getName();
+
+        // Advance until Util is found
+        int i;
+        for (i = 0; i < trace.length; i++) {
+            if (thisClassName.equals(trace[i].getName()))
+                break;
+        }
+
+        // trace[i] = Util; trace[i+1] = caller; trace[i+2] = caller's caller
+        if (i >= trace.length || i + 2 >= trace.length) {
+            throw new IllegalStateException("Failed to find org.slf4j.helpers.Util or its caller in the stack; " + "this should not happen");
+        }
+
+        return trace[i + 2];
+    }
+
+    static final public void report(String msg, Throwable t) {
+        System.err.println(msg);
+        System.err.println("Reported exception:");
+        t.printStackTrace();
+    }
+
+    static final public void report(String msg) {
+        System.err.println("SLF4J: " + msg);
+    }
+    
+	
+
+}


### PR DESCRIPTION
Upgrade slf4j wrapper to support all current slf4j formatting options for both compatibility with third party libraries (jcifs-nlg) and for performance (accept formatting string with {})

The wrapper uses 3 slf4j-api/helpers package files and adds the Logger formats imported from the official sample implementation slf4j-simple SimpleLogger